### PR TITLE
Added the methods to CA and CRL

### DIFF
--- a/goca.go
+++ b/goca.go
@@ -19,6 +19,7 @@ package goca
 import (
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 
 	storage "github.com/kairoaraujo/goca/_storage"
 )
@@ -118,14 +119,24 @@ func (c *CA) GoCertificate() *x509.Certificate {
 	return c.Data.certificate
 }
 
+// GetCRL returns Certificate Revocation List as x509 CRL string
+func (c *CA) GetCRL() string {
+	return c.Data.CRL
+}
+
+// GoCRL returns Certificate Revocation List as Go bytes *pkix.CertificateList
+func (c *CA) GoCRL() *pkix.CertificateList {
+	return c.Data.crl
+}
+
 // IsIntermediate returns if the CA is Intermediate CA (true)
 func (c *CA) IsIntermediate() bool {
 	if c.Data.CSR == "" {
 		return false
 
-	} else {
-		return true
 	}
+
+	return true
 }
 
 // ListCertificates returns all certificates in the CA

--- a/goca.go
+++ b/goca.go
@@ -131,12 +131,8 @@ func (c *CA) GoCRL() *pkix.CertificateList {
 
 // IsIntermediate returns if the CA is Intermediate CA (true)
 func (c *CA) IsIntermediate() bool {
-	if c.Data.CSR == "" {
-		return false
+	return c.Data.CSR != ""
 
-	}
-
-	return true
 }
 
 // ListCertificates returns all certificates in the CA

--- a/goca_test.go
+++ b/goca_test.go
@@ -213,4 +213,7 @@ func TestFunctionalRevokeCertificate(t *testing.T) {
 	}
 	t.Logf("Test appending revoked certificates")
 
+	if RootCA.GetCRL() == "" {
+		t.Error("CRL X509 file is empty!")
+	}
 }


### PR DESCRIPTION
Added the methods to *CA.GetCRL() that returns the x509 CRL as
string and *CA.GoCRL() that returns pkix.Certificatelist.

It makes it easier to use the CRL data.

A small improvement on CSR added.