### PR TITLE
Fix issue #3: CRL and crl is empty when CA loaded

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -168,12 +168,12 @@ func (c *CA) loadCA(commonName string) error {
 	caData := CAData{}
 
 	var (
-		caDir string = "/" + commonName + "/ca"
-		//caCertsDir      string = folderPath + "/certs"
+		caDir           string = "/" + commonName + "/ca"
 		keyString       []byte
 		publicKeyString []byte
 		csrString       []byte
 		certString      []byte
+		crlString       []byte
 		loadErr         error
 	)
 
@@ -221,6 +221,16 @@ func (c *CA) loadCA(commonName string) error {
 		}
 		caData.Certificate = string(certString)
 		caData.certificate = cert
+	}
+
+	var crlFile string = caDir + "/" + c.CommonName + crlExtension
+	if crlString, loadErr = storage.LoadFile(crlFile); loadErr == nil {
+		crl, err := cert.LoadCRL(crlString)
+		if err != nil {
+			return err
+		}
+		caData.CRL = string(crlString)
+		caData.crl = crl
 	}
 
 	c.Data = caData

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -125,6 +125,16 @@ func LoadCSR(csrString []byte) (*x509.CertificateRequest, error) {
 	return csr, nil
 }
 
+// LoadCRL loads a Certificate Revocation List from a read file.
+//
+// Using ioutil.ReadFile() satisfyies the read file.
+func LoadCRL(crlString []byte) (*pkix.CertificateList, error) {
+	block, _ := pem.Decode([]byte(string(crlString)))
+	crl, _ := x509.ParseCRL(block.Bytes)
+
+	return crl, nil
+}
+
 // CreateRootCert creates a Root CA Certificate (self signed)
 func CreateRootCert(CACommonName, commonName, country, province, locality, organization, organizationalUnit, emailAddresses string, valid int, dnsNames []string, priv *rsa.PrivateKey, pub *rsa.PublicKey, creationType storage.CreationType) (cert []byte, err error) {
 

--- a/goca.go
+++ b/goca.go
@@ -26,9 +26,8 @@ import (
 
 // CA represents the basic CA data
 type CA struct {
-	CommonName string   // Certificate Authority Common Name
-	Identity   Identity // Certificate Authority Identity (Identity{})
-	Data       CAData   // Certificate Authority Data (CAData{})
+	CommonName string // Certificate Authority Common Name
+	Data       CAData // Certificate Authority Data (CAData{})
 }
 
 // Certificate represents a Certificate data


### PR DESCRIPTION
This patch fixes the issue related to CRL and crl empty when
CA is loaded

- Closes issue #3 