### PR TITLE
chown the private key 0600 before writing to disk

### DIFF
--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -53,6 +53,9 @@ func savePEMKey(fileName string, key *rsa.PrivateKey) {
 	checkError(err)
 	defer outFile.Close()
 
+	err = os.Chmod(fileName, 0600)
+	checkError(err)
+
 	var privateKey = &pem.Block{
 		Type:  "PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),

--- a/goca_test.go
+++ b/goca_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 const CaTestFolder string = "./DoNotUseThisCAPATHTestOnly"
+const GoodKeyPerms os.FileMode = 0600
 
 func tearDown() {
 	os.Unsetenv("GOCATEST")
@@ -41,12 +42,20 @@ func TestFunctionalRootCACreation(t *testing.T) {
 		t.Errorf(RootCompanyCA.Status())
 	}
 
+	fi, err := os.Stat(CaTestFolder + "/go-root.ca/ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the CA")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
+	}
+
 	t.Log("Tested Creating a Root CA")
 
 }
 
 // Creates a Intermediate CA
-func TestFunctionalIntermediateCACration(t *testing.T) {
+func TestFunctionalIntermediateCACreation(t *testing.T) {
 	os.Setenv("CAPATH", CaTestFolder)
 
 	intermediateCAIdentity := Identity{
@@ -70,6 +79,14 @@ func TestFunctionalIntermediateCACration(t *testing.T) {
 
 	if IntermediateCA.Status() != "Intermediate Certificate Authority not ready, missing Certificate." {
 		t.Errorf(IntermediateCA.Status())
+	}
+
+	fi, err := os.Stat(CaTestFolder + "/go-itermediate.ca/ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the CA")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
 	}
 
 	t.Log("Tested Creating a Intermediate CA")
@@ -162,6 +179,13 @@ func TestFunctionalRootCAIssueNewCertificate(t *testing.T) {
 		t.Error("The CA Certificate is not the same as the Certificate CA Certificate")
 	}
 
+	fi, err := os.Stat(CaTestFolder + "/go-root.ca/certs/intranet.go-root.ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the identity")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
+	}
 }
 
 func TestFunctionalRootCALoadCertificates(t *testing.T) {


### PR DESCRIPTION
When saving a new RSA key to disk (key.pem), goca defaults to 0644 Unix permissions on the file. This is undesirable since this makes the private key readable to any user with shell access to the local system.

This change sets the permissions of the key.pem file to 0600 after the file is created but before the byte slice containing the RSA private key is written to disk.