### PR TITLE
Issue8

### DIFF
--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -290,6 +290,18 @@ func LoadFile(fileName string) ([]byte, error) {
 
 }
 
+// LinkFile creates a symlink from oldFile to newFile under the $CAPATH hierarchy.
+func LinkFile(oldFile string, newFile string) error {
+	caPath, err := CAPathIsReady()
+	if err != nil {
+		return err
+	}
+
+	err = os.Symlink(oldFile, caPath+"/"+newFile)
+
+	return err
+}
+
 func listDirs(path string) []string {
 	caPath, err := CAPathIsReady()
 	if err != nil {

--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -27,6 +27,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -38,6 +39,8 @@ const (
 	PEMFile       = "key.pem"
 	PublicPEMFile = "key.pub"
 )
+
+var ErrIncompleteCopy = errors.New("file copy was incomplete")
 
 func checkError(err error) error {
 	if err != nil {
@@ -288,6 +291,46 @@ func LoadFile(fileName string) ([]byte, error) {
 
 	return fileData, nil
 
+}
+
+// CopyFile copies the specified src file to the given destination.
+// Both paths are relative to the $CAPATH hierarchy.
+func CopyFile(src, dest string) error {
+	caPath, err := CAPathIsReady()
+	if err != nil {
+		return err
+	}
+
+	srcPath := filepath.Join(caPath, src)
+	destPath := filepath.Join(caPath, dest)
+
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	inStat, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, inStat.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	written, err := io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+
+	if written != inStat.Size() {
+		return ErrIncompleteCopy
+	}
+
+	return nil
 }
 
 func listDirs(path string) []string {

--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -290,18 +290,6 @@ func LoadFile(fileName string) ([]byte, error) {
 
 }
 
-// LinkFile creates a symlink from oldFile to newFile under the $CAPATH hierarchy.
-func LinkFile(oldFile string, newFile string) error {
-	caPath, err := CAPathIsReady()
-	if err != nil {
-		return err
-	}
-
-	err = os.Symlink(oldFile, caPath+"/"+newFile)
-
-	return err
-}
-
 func listDirs(path string) []string {
 	caPath, err := CAPathIsReady()
 	if err != nil {

--- a/ca.go
+++ b/ca.go
@@ -281,7 +281,7 @@ func (c *CA) signCSR(csr x509.CertificateRequest, valid int) (certificate Certif
 
 	// Are we signing an intermediate CA? See issue #8.
 	caCsrFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + csrExtension
-	if _, err = storage.LoadFile(caCsrFile); err == nil {
+	if _, err := storage.LoadFile(caCsrFile); err == nil {
 		// Use a relative path to handle case when $CAPATH is relative, rather than absolute.
 		certFile := "../../" + c.CommonName + "/certs/" + certificate.commonName + "/" + certificate.commonName + certExtension
 		linkFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + certExtension

--- a/ca.go
+++ b/ca.go
@@ -279,15 +279,6 @@ func (c *CA) signCSR(csr x509.CertificateRequest, valid int) (certificate Certif
 
 	certificate.certificate = cert
 
-	// Are we signing an intermediate CA? See issue #8.
-	caCsrFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + csrExtension
-	if _, err := storage.LoadFile(caCsrFile); err == nil {
-		// Use a relative path to handle case when $CAPATH is relative, rather than absolute.
-		certFile := "../../" + c.CommonName + "/certs/" + certificate.commonName + "/" + certificate.commonName + certExtension
-		linkFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + certExtension
-		err = storage.LinkFile(certFile, linkFile)
-	}
-
 	return certificate, err
 
 }

--- a/ca.go
+++ b/ca.go
@@ -281,7 +281,7 @@ func (c *CA) signCSR(csr x509.CertificateRequest, valid int) (certificate Certif
 
 	// Are we signing an intermediate CA? See issue #8.
 	caCsrFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + csrExtension
-	if _, err := storage.LoadFile(caCsrFile); err == nil {
+	if _, err = storage.LoadFile(caCsrFile); err == nil {
 		// Use a relative path to handle case when $CAPATH is relative, rather than absolute.
 		certFile := "../../" + c.CommonName + "/certs/" + certificate.commonName + "/" + certificate.commonName + certExtension
 		linkFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + certExtension

--- a/ca.go
+++ b/ca.go
@@ -279,6 +279,15 @@ func (c *CA) signCSR(csr x509.CertificateRequest, valid int) (certificate Certif
 
 	certificate.certificate = cert
 
+	// Are we signing an intermediate CA? See issue #8.
+	caCsrFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + csrExtension
+	if _, err := storage.LoadFile(caCsrFile); err == nil {
+		// Use a relative path to handle case when $CAPATH is relative, rather than absolute.
+		certFile := "../../" + c.CommonName + "/certs/" + certificate.commonName + "/" + certificate.commonName + certExtension
+		linkFile := "/" + certificate.commonName + "/ca/" + certificate.commonName + certExtension
+		err = storage.LinkFile(certFile, linkFile)
+	}
+
 	return certificate, err
 
 }

--- a/goca_test.go
+++ b/goca_test.go
@@ -67,7 +67,7 @@ func TestFunctionalIntermediateCACreation(t *testing.T) {
 		Intermediate:       true,
 	}
 
-	IntermediateCA, err := New("go-itermediate.ca", intermediateCAIdentity)
+	IntermediateCA, err := New("go-intermediate.ca", intermediateCAIdentity)
 	if err != nil {
 		t.Log(err)
 		t.Errorf("Failing to create the CA")
@@ -81,7 +81,7 @@ func TestFunctionalIntermediateCACreation(t *testing.T) {
 		t.Errorf(IntermediateCA.Status())
 	}
 
-	fi, err := os.Stat(CaTestFolder + "/go-itermediate.ca/ca/key.pem")
+	fi, err := os.Stat(CaTestFolder + "/go-intermediate.ca/ca/key.pem")
 	if err != nil {
 		t.Errorf("key.pem does not exist for the CA")
 	}
@@ -121,7 +121,7 @@ func TestFunctionalRootCASignsIntermediateCA(t *testing.T) {
 	}
 
 	t.Log("Tested load Intermediate CA")
-	IntermediateCA, err := Load("go-itermediate.ca")
+	IntermediateCA, err := Load("go-intermediate.ca")
 
 	if err != nil {
 		t.Log(err)
@@ -205,7 +205,7 @@ func TestFunctionalRootCALoadCertificates(t *testing.T) {
 	if intranetCert.GetCACertificate() != "" {
 		t.Log("Failed to load intranet")
 	}
-	intermediateCert, _ := RootCA.LoadCertificate("go-itermediate.ca")
+	intermediateCert, _ := RootCA.LoadCertificate("go-intermediate.ca")
 
 	if RootCA.GetCertificate() != intermediateCert.GetCACertificate() {
 		t.Log(RootCA.GetCertificate())
@@ -217,13 +217,13 @@ func TestFunctionalRootCALoadCertificates(t *testing.T) {
 
 func TestFunctionalRevokeCertificate(t *testing.T) {
 	RootCA, _ := Load("go-root.ca")
-	intermediateCert, _ := RootCA.LoadCertificate("go-itermediate.ca")
+	intermediateCert, _ := RootCA.LoadCertificate("go-intermediate.ca")
 
 	if RootCA.Data.crl == nil {
 		t.Error("CRL is nil")
 	}
 
-	err := RootCA.RevokeCertificate("go-itermediate.ca")
+	err := RootCA.RevokeCertificate("go-intermediate.ca")
 	if err != nil {
 		t.Error("Failed to revoke certificate")
 	}

--- a/goca_test.go
+++ b/goca_test.go
@@ -220,6 +220,34 @@ func TestFunctionalRootCALoadCertificates(t *testing.T) {
 
 }
 
+func TestFunctionalIntermediateCAIssueNewCertificate(t *testing.T) {
+	id := Identity{
+		Organization:       "An Organization",
+		OrganizationalUnit: "An Organizational Unit",
+		Country:            "NL",
+		Locality:           "Noord-Brabant",
+		Province:           "Veldhoven",
+		Intermediate:       false,
+		DNSNames:           []string{"anorg.go-intermediate.ca"},
+	}
+
+	interCA, err := Load("go-intermediate.ca")
+	if err != nil {
+		t.Errorf("Failed to load intermediate CA")
+	}
+
+	idCert, err := interCA.IssueCertificate("anorg.go-intermediate.ca", id)
+	if err != nil {
+		t.Error("Failed to issue certificate anorg.go-intermediate.ca")
+	}
+
+	fmt.Println(interCA.ListCertificates())
+
+	if interCA.GetCertificate() != idCert.GetCACertificate() {
+		t.Error("CA certificate mismatch between intermediate CA and issued certificate.")
+	}
+}
+
 func TestFunctionalRevokeCertificate(t *testing.T) {
 	RootCA, _ := Load("go-root.ca")
 	intermediateCert, _ := RootCA.LoadCertificate("go-intermediate.ca")

--- a/goca_test.go
+++ b/goca_test.go
@@ -145,6 +145,11 @@ func TestFunctionalRootCASignsIntermediateCA(t *testing.T) {
 	}
 	t.Log("Tested Sign CSR with correct valid days (365)")
 
+	_, err = os.Stat(CaTestFolder + "/go-intermediate.ca/ca/go-intermediate.ca.crt")
+	if err != nil {
+		t.Errorf("Intermediate CA certificate not in intermediate CA directory")
+	}
+
 	fmt.Println(RootCA.ListCertificates())
 }
 


### PR DESCRIPTION
This pull request is to fix issue #8.

Originally, I wanted to have goca just place the intermediate .crt under the intermediate's own ca directory. But after some consideration I realized this would break other functionality, for example if we wanted to revoke the intermediate the root CA would not be able to find the intermediate.

Rather than make it difficult to preserve the existing API both in goca proper and the REST interface, I chose to internalize the workaround I developed as a special branch in `CA.SignCSR()`. 