### PR TITLE
Issue 11 Use filepath.Join to avoid hardcoded path separators

### DIFF
--- a/rest-api/controllers/controllers.go
+++ b/rest-api/controllers/controllers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -194,7 +195,7 @@ func UploadCertificateICA(c *gin.Context) {
 
 	certUploaded, _ := c.FormFile("file")
 	fileName := uuid.New().String()
-	fileNameFull := os.Getenv("CAPATH") + "/" + fileName
+	fileNameFull := filepath.Join(os.Getenv("CAPATH"), fileName)
 	if err := c.SaveUploadedFile(certUploaded, fileNameFull); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -271,7 +272,7 @@ func SignCSR(c *gin.Context) {
 	}
 
 	fileName := uuid.New().String()
-	fileNameFull := os.Getenv("CAPATH") + "/" + fileName
+	fileNameFull := filepath.Join(os.Getenv("CAPATH"), fileName)
 	if err := c.SaveUploadedFile(csrUploaded, fileNameFull); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
This should solve #11 . I did not change example_test.go however since `/opt/GoCA/CA` as a path is a pretty heavy unixism to begin with and would need more than just  filepath.Join to fix.

I also did not change the hardcoded check in `caPathInit` for ".//" as that seems to be for testing not normal operation.

I did try to extend the storage functions to take variadic parameters where possible so you can for example call `LoadFile("dir1", "dir2", "file.pem")` instead of `LoadFile(filepath.Join("dir1", "dir2", "file.pem"))`

Something I did notice however is there is a lot of use of `os.Stat(); os.IsNotExist()` for example in `CheckCertExists` This is a bit of an anti pattern it would be better to attempt to open the file and check `os.IsNotExist` if opening the file returns an error.