### PR TITLE
tighten local file permissions on private keys

### DIFF
--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -53,6 +53,9 @@ func savePEMKey(fileName string, key *rsa.PrivateKey) {
 	checkError(err)
 	defer outFile.Close()
 
+	err = os.Chmod(fileName, 0600)
+	checkError(err)
+
 	var privateKey = &pem.Block{
 		Type:  "PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),

--- a/goca_test.go
+++ b/goca_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 const CaTestFolder string = "./DoNotUseThisCAPATHTestOnly"
+const GoodKeyPerms os.FileMode = 0600
 
 func tearDown() {
 	os.Unsetenv("GOCATEST")
@@ -41,12 +42,20 @@ func TestFunctionalRootCACreation(t *testing.T) {
 		t.Errorf(RootCompanyCA.Status())
 	}
 
+	fi, err := os.Stat(CaTestFolder + "/go-root.ca/ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the CA")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
+	}
+
 	t.Log("Tested Creating a Root CA")
 
 }
 
 // Creates a Intermediate CA
-func TestFunctionalIntermediateCACration(t *testing.T) {
+func TestFunctionalIntermediateCACreation(t *testing.T) {
 	os.Setenv("CAPATH", CaTestFolder)
 
 	intermediateCAIdentity := Identity{
@@ -70,6 +79,14 @@ func TestFunctionalIntermediateCACration(t *testing.T) {
 
 	if IntermediateCA.Status() != "Intermediate Certificate Authority not ready, missing Certificate." {
 		t.Errorf(IntermediateCA.Status())
+	}
+
+	fi, err := os.Stat(CaTestFolder + "/go-itermediate.ca/ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the CA")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
 	}
 
 	t.Log("Tested Creating a Intermediate CA")
@@ -162,6 +179,13 @@ func TestFunctionalRootCAIssueNewCertificate(t *testing.T) {
 		t.Error("The CA Certificate is not the same as the Certificate CA Certificate")
 	}
 
+	fi, err := os.Stat(CaTestFolder + "/go-root.ca/certs/intranet.go-root.ca/key.pem")
+	if err != nil {
+		t.Errorf("key.pem does not exist for the identity")
+	}
+	if fi.Mode() != GoodKeyPerms {
+		t.Errorf("Expected key.pem permissions " + fmt.Sprint(GoodKeyPerms) + " but got: " + fmt.Sprint(fi.Mode()))
+	}
 }
 
 func TestFunctionalRootCALoadCertificates(t *testing.T) {

--- a/goca_test.go
+++ b/goca_test.go
@@ -3,6 +3,7 @@ package goca
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -42,7 +43,7 @@ func TestFunctionalRootCACreation(t *testing.T) {
 		t.Errorf(RootCompanyCA.Status())
 	}
 
-	fi, err := os.Stat(CaTestFolder + "/go-root.ca/ca/key.pem")
+	fi, err := os.Stat(filepath.Join(CaTestFolder, "go-root.ca", "ca", "key.pem"))
 	if err != nil {
 		t.Errorf("key.pem does not exist for the CA")
 	}
@@ -81,7 +82,7 @@ func TestFunctionalIntermediateCACreation(t *testing.T) {
 		t.Errorf(IntermediateCA.Status())
 	}
 
-	fi, err := os.Stat(CaTestFolder + "/go-itermediate.ca/ca/key.pem")
+	fi, err := os.Stat(filepath.Join(CaTestFolder, "go-itermediate.ca", "ca", "key.pem"))
 	if err != nil {
 		t.Errorf("key.pem does not exist for the CA")
 	}
@@ -179,7 +180,7 @@ func TestFunctionalRootCAIssueNewCertificate(t *testing.T) {
 		t.Error("The CA Certificate is not the same as the Certificate CA Certificate")
 	}
 
-	fi, err := os.Stat(CaTestFolder + "/go-root.ca/certs/intranet.go-root.ca/key.pem")
+	fi, err := os.Stat(filepath.Join(CaTestFolder, "go-root.ca", "certs", "intranet.go-root.ca", "key.pem"))
 	if err != nil {
 		t.Errorf("key.pem does not exist for the identity")
 	}


### PR DESCRIPTION
Private keys are created with permissive permissions. Instead, tighten the permissions to limit access for shell accounts on the host system.