### PR TITLE
Support different ports in rest-api

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -377,7 +378,7 @@ func (c *CA) loadCertificate(commonName string) (certificate Certificate, err er
 		loadErr         error
 	)
 
-	if _, err := os.Stat(filepath.Join(os.Getenv("CAPATH"), caCertsDir)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(os.Getenv("CAPATH"), caCertsDir)); errors.Is(err, fs.ErrNotExist) {
 		return certificate, ErrCertLoadNotFound
 	}
 

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -22,13 +22,13 @@
 
 // Package cert provides RSA Key API management for crypto/x509 certificates.
 //
-//
 // This package makes easy to generate and certificates from files to be used
 // by GoLang applications.
 //
 // Generating Certificates (even by Signing), the files will be saved in the
 // $CAPATH by default.
-//For $CAPATH, please check out the GoCA documentation.
+// For $CAPATH, please check out the GoCA documentation.
+
 package cert
 
 import (

--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -20,6 +23,11 @@ import (
 // @license.name MIT
 // @license.url https://opensource.org/licenses/MIT
 func main() {
+
+	var port int
+
+	flag.IntVar(&port, "p", 80, "Port to listen, default is 80")
+	flag.Parse()
 
 	router := gin.Default()
 	// Set a lower memory limit for multipart forms (default is 32 MiB)
@@ -42,7 +50,7 @@ func main() {
 	v1.GET("/ca/:cn/certificates/:cert_cn", controllers.GetCertificatesCommonName)
 
 	// Run the server
-	err := router.Run(":80")
+	err := router.Run(fmt.Sprintf(":%d", port))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Add command line argument support in REST API module so that users can choose different port when starting the server.

This PR also contains a few minor cosmetic fixes.