### PR TITLE
perf: Added CAPATH to the cmd parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.out
 DoNotUseThisCAPATHTestOnly/
 docs-test/
 cover.out
+store

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ docker-image:
 
 lint:
 	golangci-lint run -e gosec
+
+start:
+	go run rest-api/main.go -capath="./store" -p 81

--- a/_storage/storage.go
+++ b/_storage/storage.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020, Kairo de Araujo
+// # Copyright (c) 2020, Kairo de Araujo
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -60,7 +60,7 @@ func savePEMKey(fileName string, key *rsa.PrivateKey) {
 	checkError(err)
 
 	var privateKey = &pem.Block{
-		Type:  "PRIVATE KEY",
+		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}
 
@@ -73,7 +73,7 @@ func savePublicPEMKey(fileName string, pubkey rsa.PublicKey) {
 	checkError(err)
 
 	var pemkey = &pem.Block{
-		Type:  "PUBLIC KEY",
+		Type:  "RSA PUBLIC KEY",
 		Bytes: asn1Bytes,
 	}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -108,6 +108,15 @@ const docTemplate = `{
                     "CA"
                 ],
                 "summary": "Certificate Authorities (CA) Information based in Common Name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -140,6 +149,15 @@ const docTemplate = `{
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "List all Certificates managed by a certain Certificate Authority",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -174,6 +192,13 @@ const docTemplate = `{
                 ],
                 "summary": "CA issue new certificate",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Add new Certificate Authority or Intermediate Certificate Authority",
                         "name": "ca",
@@ -216,6 +241,22 @@ const docTemplate = `{
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "Get information about a Certificate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Common Name of Certificate",
+                        "name": "certificate_cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -249,6 +290,22 @@ const docTemplate = `{
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "CA revoke a existent certificate managed by CA",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Common Name of Certificate",
+                        "name": "certificate_cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -427,77 +484,6 @@ const docTemplate = `{
                 }
             }
         },
-        "goca.Identity": {
-            "type": "object",
-            "properties": {
-                "country": {
-                    "description": "Country (two letters)",
-                    "type": "string",
-                    "example": "NL"
-                },
-                "dns_names": {
-                    "description": "DNS Names list",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ca.example.com",
-                        "root-ca.example.com"
-                    ]
-                },
-                "email": {
-                    "description": "Email Address",
-                    "type": "string",
-                    "example": "sec@company.com"
-                },
-                "intermediate": {
-                    "description": "Intermendiate Certificate Authority (default is false)",
-                    "type": "boolean",
-                    "example": false
-                },
-                "ip_addresses": {
-                    "description": "IP Address list",
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "key_size": {
-                    "description": "Key Bit Size (defaul: 2048)",
-                    "type": "integer",
-                    "example": 2048
-                },
-                "locality": {
-                    "description": "Locality name",
-                    "type": "string",
-                    "example": "Noord-Brabant"
-                },
-                "organization": {
-                    "description": "Organization name",
-                    "type": "string",
-                    "example": "Company"
-                },
-                "organization_unit": {
-                    "description": "Organizational Unit name",
-                    "type": "string",
-                    "example": "Security Management"
-                },
-                "province": {
-                    "description": "Province name",
-                    "type": "string",
-                    "example": "Veldhoven"
-                },
-                "valid": {
-                    "description": "Minimum 1 day, maximum 825 days -- Default: 397",
-                    "type": "integer",
-                    "example": 365
-                }
-            }
-        },
         "models.CABody": {
             "type": "object",
             "properties": {
@@ -538,6 +524,16 @@ const docTemplate = `{
                 },
                 "intermediate": {
                     "type": "boolean"
+                },
+                "ip_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.2.1"
+                    ]
                 },
                 "issue_date": {
                     "type": "string",
@@ -587,6 +583,16 @@ const docTemplate = `{
                 "files": {
                     "$ref": "#/definitions/goca.Certificate"
                 },
+                "ip_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.0.1"
+                    ]
+                },
                 "issue_date": {
                     "type": "string",
                     "example": "2021-01-06 10:31:43 +0000 UTC"
@@ -598,7 +604,96 @@ const docTemplate = `{
             }
         },
         "models.Payload": {
-            "type": "object"
+            "type": "object",
+            "required": [
+                "common_name",
+                "identity"
+            ],
+            "properties": {
+                "common_name": {
+                    "type": "string",
+                    "example": "root-ca"
+                },
+                "identity": {
+                    "$ref": "#/definitions/models.PayloadIdentity"
+                },
+                "parent_common_name": {
+                    "type": "string",
+                    "example": "root-ca"
+                }
+            }
+        },
+        "models.PayloadIdentity": {
+            "type": "object",
+            "properties": {
+                "country": {
+                    "description": "Country (two letters)",
+                    "type": "string",
+                    "example": "NL"
+                },
+                "dns_names": {
+                    "description": "DNS Names list",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ca.example.com",
+                        "root-ca.example.com"
+                    ]
+                },
+                "email": {
+                    "description": "Email Address",
+                    "type": "string",
+                    "example": "sec@company.com"
+                },
+                "intermediate": {
+                    "description": "Intermendiate Certificate Authority (default is false)",
+                    "type": "boolean",
+                    "example": false
+                },
+                "ip_addresses": {
+                    "description": "IP Address list",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.0.1"
+                    ]
+                },
+                "key_size": {
+                    "description": "Key Bit Size (defaul: 2048)",
+                    "type": "integer",
+                    "example": 2048
+                },
+                "locality": {
+                    "description": "Locality name",
+                    "type": "string",
+                    "example": "Noord-Brabant"
+                },
+                "organization": {
+                    "description": "Organization name",
+                    "type": "string",
+                    "example": "Company"
+                },
+                "organization_unit": {
+                    "description": "Organizational Unit name",
+                    "type": "string",
+                    "example": "Security Management"
+                },
+                "province": {
+                    "description": "Province name",
+                    "type": "string",
+                    "example": "Veldhoven"
+                },
+                "valid": {
+                    "description": "Minimum 1 day, maximum 825 days -- Default: 397",
+                    "type": "integer",
+                    "example": 365
+                }
+            }
         },
         "models.ResponseCA": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -103,6 +103,15 @@
                     "CA"
                 ],
                 "summary": "Certificate Authorities (CA) Information based in Common Name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -135,6 +144,15 @@
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "List all Certificates managed by a certain Certificate Authority",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -169,6 +187,13 @@
                 ],
                 "summary": "CA issue new certificate",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Add new Certificate Authority or Intermediate Certificate Authority",
                         "name": "ca",
@@ -211,6 +236,22 @@
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "Get information about a Certificate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Common Name of Certificate",
+                        "name": "certificate_cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -244,6 +285,22 @@
                     "CA/{CN}/Certificates"
                 ],
                 "summary": "CA revoke a existent certificate managed by CA",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Common Name of the Certificate Authority",
+                        "name": "cn",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Common Name of Certificate",
+                        "name": "certificate_cn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -422,77 +479,6 @@
                 }
             }
         },
-        "goca.Identity": {
-            "type": "object",
-            "properties": {
-                "country": {
-                    "description": "Country (two letters)",
-                    "type": "string",
-                    "example": "NL"
-                },
-                "dns_names": {
-                    "description": "DNS Names list",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ca.example.com",
-                        "root-ca.example.com"
-                    ]
-                },
-                "email": {
-                    "description": "Email Address",
-                    "type": "string",
-                    "example": "sec@company.com"
-                },
-                "intermediate": {
-                    "description": "Intermendiate Certificate Authority (default is false)",
-                    "type": "boolean",
-                    "example": false
-                },
-                "ip_addresses": {
-                    "description": "IP Address list",
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "key_size": {
-                    "description": "Key Bit Size (defaul: 2048)",
-                    "type": "integer",
-                    "example": 2048
-                },
-                "locality": {
-                    "description": "Locality name",
-                    "type": "string",
-                    "example": "Noord-Brabant"
-                },
-                "organization": {
-                    "description": "Organization name",
-                    "type": "string",
-                    "example": "Company"
-                },
-                "organization_unit": {
-                    "description": "Organizational Unit name",
-                    "type": "string",
-                    "example": "Security Management"
-                },
-                "province": {
-                    "description": "Province name",
-                    "type": "string",
-                    "example": "Veldhoven"
-                },
-                "valid": {
-                    "description": "Minimum 1 day, maximum 825 days -- Default: 397",
-                    "type": "integer",
-                    "example": 365
-                }
-            }
-        },
         "models.CABody": {
             "type": "object",
             "properties": {
@@ -533,6 +519,16 @@
                 },
                 "intermediate": {
                     "type": "boolean"
+                },
+                "ip_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.2.1"
+                    ]
                 },
                 "issue_date": {
                     "type": "string",
@@ -582,6 +578,16 @@
                 "files": {
                     "$ref": "#/definitions/goca.Certificate"
                 },
+                "ip_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.0.1"
+                    ]
+                },
                 "issue_date": {
                     "type": "string",
                     "example": "2021-01-06 10:31:43 +0000 UTC"
@@ -604,11 +610,83 @@
                     "example": "root-ca"
                 },
                 "identity": {
-                    "$ref": "#/definitions/goca.Identity"
+                    "$ref": "#/definitions/models.PayloadIdentity"
                 },
                 "parent_common_name": {
                     "type": "string",
                     "example": "root-ca"
+                }
+            }
+        },
+        "models.PayloadIdentity": {
+            "type": "object",
+            "properties": {
+                "country": {
+                    "description": "Country (two letters)",
+                    "type": "string",
+                    "example": "NL"
+                },
+                "dns_names": {
+                    "description": "DNS Names list",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ca.example.com",
+                        "root-ca.example.com"
+                    ]
+                },
+                "email": {
+                    "description": "Email Address",
+                    "type": "string",
+                    "example": "sec@company.com"
+                },
+                "intermediate": {
+                    "description": "Intermendiate Certificate Authority (default is false)",
+                    "type": "boolean",
+                    "example": false
+                },
+                "ip_addresses": {
+                    "description": "IP Address list",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "127.0.0.1",
+                        "192.168.0.1"
+                    ]
+                },
+                "key_size": {
+                    "description": "Key Bit Size (defaul: 2048)",
+                    "type": "integer",
+                    "example": 2048
+                },
+                "locality": {
+                    "description": "Locality name",
+                    "type": "string",
+                    "example": "Noord-Brabant"
+                },
+                "organization": {
+                    "description": "Organization name",
+                    "type": "string",
+                    "example": "Company"
+                },
+                "organization_unit": {
+                    "description": "Organizational Unit name",
+                    "type": "string",
+                    "example": "Security Management"
+                },
+                "province": {
+                    "description": "Province name",
+                    "type": "string",
+                    "example": "Veldhoven"
+                },
+                "valid": {
+                    "description": "Minimum 1 day, maximum 825 days -- Default: 397",
+                    "type": "integer",
+                    "example": 365
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -57,60 +57,6 @@ definitions:
           -----BEGIN PUBLIC KEY-----...-----END PUBLIC KEY-----
         type: string
     type: object
-  goca.Identity:
-    properties:
-      country:
-        description: Country (two letters)
-        example: NL
-        type: string
-      dns_names:
-        description: DNS Names list
-        example:
-        - ca.example.com
-        - root-ca.example.com
-        items:
-          type: string
-        type: array
-      email:
-        description: Email Address
-        example: sec@company.com
-        type: string
-      intermediate:
-        description: Intermendiate Certificate Authority (default is false)
-        example: false
-        type: boolean
-      ip_addresses:
-        description: IP Address list
-        items:
-          items:
-            type: integer
-          type: array
-        type: array
-      key_size:
-        description: 'Key Bit Size (defaul: 2048)'
-        example: 2048
-        type: integer
-      locality:
-        description: Locality name
-        example: Noord-Brabant
-        type: string
-      organization:
-        description: Organization name
-        example: Company
-        type: string
-      organization_unit:
-        description: Organizational Unit name
-        example: Security Management
-        type: string
-      province:
-        description: Province name
-        example: Veldhoven
-        type: string
-      valid:
-        description: 'Minimum 1 day, maximum 825 days -- Default: 397'
-        example: 365
-        type: integer
-    type: object
   models.CABody:
     properties:
       certificates:
@@ -140,6 +86,13 @@ definitions:
         $ref: '#/definitions/goca.CAData'
       intermediate:
         type: boolean
+      ip_addresses:
+        example:
+        - 127.0.0.1
+        - 192.168.2.1
+        items:
+          type: string
+        type: array
       issue_date:
         example: 2021-01-06 10:31:43 +0000 UTC
         type: string
@@ -174,6 +127,13 @@ definitions:
         type: string
       files:
         $ref: '#/definitions/goca.Certificate'
+      ip_addresses:
+        example:
+        - 127.0.0.1
+        - 192.168.0.1
+        items:
+          type: string
+        type: array
       issue_date:
         example: 2021-01-06 10:31:43 +0000 UTC
         type: string
@@ -187,13 +147,68 @@ definitions:
         example: root-ca
         type: string
       identity:
-        $ref: '#/definitions/goca.Identity'
+        $ref: '#/definitions/models.PayloadIdentity'
       parent_common_name:
         example: root-ca
         type: string
     required:
     - common_name
     - identity
+    type: object
+  models.PayloadIdentity:
+    properties:
+      country:
+        description: Country (two letters)
+        example: NL
+        type: string
+      dns_names:
+        description: DNS Names list
+        example:
+        - ca.example.com
+        - root-ca.example.com
+        items:
+          type: string
+        type: array
+      email:
+        description: Email Address
+        example: sec@company.com
+        type: string
+      intermediate:
+        description: Intermendiate Certificate Authority (default is false)
+        example: false
+        type: boolean
+      ip_addresses:
+        description: IP Address list
+        example:
+        - 127.0.0.1
+        - 192.168.0.1
+        items:
+          type: string
+        type: array
+      key_size:
+        description: 'Key Bit Size (defaul: 2048)'
+        example: 2048
+        type: integer
+      locality:
+        description: Locality name
+        example: Noord-Brabant
+        type: string
+      organization:
+        description: Organization name
+        example: Company
+        type: string
+      organization_unit:
+        description: Organizational Unit name
+        example: Security Management
+        type: string
+      province:
+        description: Province name
+        example: Veldhoven
+        type: string
+      valid:
+        description: 'Minimum 1 day, maximum 825 days -- Default: 397'
+        example: 365
+        type: integer
     type: object
   models.ResponseCA:
     properties:
@@ -286,6 +301,12 @@ paths:
   /api/v1/ca/{cn}:
     get:
       description: list the Certificate Authorities data
+      parameters:
+      - description: Common Name
+        in: path
+        name: cn
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -308,6 +329,12 @@ paths:
     get:
       description: list all certificates managed by a certain Certificate Authority
         (cn)
+      parameters:
+      - description: Common Name of the Certificate Authority
+        in: path
+        name: cn
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -331,6 +358,11 @@ paths:
       - application/json
       description: the Certificate Authority issues a new Certificate
       parameters:
+      - description: Common Name of the Certificate Authority
+        in: path
+        name: cn
+        required: true
+        type: string
       - description: Add new Certificate Authority or Intermediate Certificate Authority
         in: body
         name: ca
@@ -360,6 +392,17 @@ paths:
       consumes:
       - application/json
       description: the Certificate Authority revokes a managed Certificate
+      parameters:
+      - description: Common Name of the Certificate Authority
+        in: path
+        name: cn
+        required: true
+        type: string
+      - description: Common Name of Certificate
+        in: path
+        name: certificate_cn
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -380,6 +423,17 @@ paths:
       - CA/{CN}/Certificates
     get:
       description: get information about a certificate issued by a certain CA
+      parameters:
+      - description: Common Name of the Certificate Authority
+        in: path
+        name: cn
+        required: true
+        type: string
+      - description: Common Name of Certificate
+        in: path
+        name: certificate_cn
+        required: true
+        type: string
       produces:
       - application/json
       responses:

--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -25,9 +26,19 @@ import (
 func main() {
 
 	var port int
+	var capath string
 
 	flag.IntVar(&port, "p", 80, "Port to listen, default is 80")
+	flag.StringVar(&capath, "capath", ".", "Path to save certificates")
+	help := flag.Bool("help", false, "Get hints about arguments")
 	flag.Parse()
+	if *help {
+		flag.Usage()
+		return
+	}
+	if capath != "" {
+		os.Setenv("CAPATH", capath)
+	}
 
 	router := gin.Default()
 	// Set a lower memory limit for multipart forms (default is 32 MiB)

--- a/rest-api/models/models.go
+++ b/rest-api/models/models.go
@@ -21,9 +21,23 @@ type ResponseList struct {
 }
 
 type Payload struct {
-	CommonName       string        `json:"common_name" example:"root-ca" binding:"required"`
-	ParentCommonName string        `json:"parent_common_name" example:"root-ca"`
-	Identity         goca.Identity `json:"identity" binding:"required"`
+	CommonName       string          `json:"common_name" example:"root-ca" binding:"required"`
+	ParentCommonName string          `json:"parent_common_name" example:"root-ca"`
+	Identity         PayloadIdentity `json:"identity" binding:"required"`
+}
+
+type PayloadIdentity struct {
+	Organization       string   `json:"organization" example:"Company"`                         // Organization name
+	OrganizationalUnit string   `json:"organization_unit" example:"Security Management"`        // Organizational Unit name
+	Country            string   `json:"country" example:"NL"`                                   // Country (two letters)
+	Locality           string   `json:"locality" example:"Noord-Brabant"`                       // Locality name
+	Province           string   `json:"province" example:"Veldhoven"`                           // Province name
+	EmailAddresses     string   `json:"email" example:"sec@company.com"`                        // Email Address
+	DNSNames           []string `json:"dns_names" example:"ca.example.com,root-ca.example.com"` // DNS Names list
+	IPAddresses        []string `json:"ip_addresses,omitempty" example:"127.0.0.1,192.168.0.1"` // IP Address list
+	Intermediate       bool     `json:"intermediate" example:"false"`                           // Intermendiate Certificate Authority (default is false)
+	KeyBitSize         int      `json:"key_size" example:"2048"`                                // Key Bit Size (defaul: 2048)
+	Valid              int      `json:"valid" example:"365"`                                    // Minimum 1 day, maximum 825 days -- Default: 397
 }
 
 type CABody struct {
@@ -34,6 +48,7 @@ type CABody struct {
 	IssueDate                 string      `json:"issue_date" example:"2021-01-06 10:31:43 +0000 UTC"`
 	ExpireDate                string      `json:"expire_date" example:"2022-01-06 10:31:43 +0000 UTC"`
 	DNSNames                  []string    `json:"dns_names" example:"ca.example.ca,root-ca.example.com"`
+	IPAddresses               []string    `json:"ip_addresses" example:"127.0.0.1,192.168.2.1"`
 	CSR                       bool        `json:"csr" example:"false"`
 	Certificates              []string    `json:"certificates" example:"intranet.example.com,w3.example.com"`
 	CertificateRevocationList []string    `json:"revoked_certificates" example:"38188836191244388427366318074605547405,338255903472757769326153358304310617728"`
@@ -46,5 +61,6 @@ type CertificateBody struct {
 	IssueDate    string           `json:"issue_date" example:"2021-01-06 10:31:43 +0000 UTC"`
 	ExpireDate   string           `json:"expire_date" example:"2022-01-06 10:31:43 +0000 UTC"`
 	DNSNames     []string         `json:"dns_names" example:"w3.intranet.go-root.ca,intranet.go-root.ca"`
+	IPAddresses  []string         `json:"ip_addresses" example:"127.0.0.1,192.168.0.1"`
 	Files        goca.Certificate `json:"files"`
 }

--- a/rest-api/utils/utils.go
+++ b/rest-api/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"net"
+)
+
+// Parse []string to []net.IP
+func ParseStrings2IPs(ipStrings []string) []net.IP {
+	result := []net.IP{}
+
+	for _, str := range ipStrings {
+		ip := net.ParseIP(str)
+		if ip == nil {
+			continue
+		}
+
+		result = append(result, ip)
+	}
+
+	return result
+}
+
+// Parse []net.IP to []string
+func ParseIPs2Strings(ips []net.IP) []string {
+	result := []string{}
+
+	for _, ip := range ips {
+		result = append(result, ip.String())
+	}
+
+	return result
+}

--- a/rest-api/utils/utils_test.go
+++ b/rest-api/utils/utils_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"log"
+	"testing"
+)
+
+func TestParseIP(t *testing.T) {
+	ips := ParseStrings2IPs([]string{
+		"192.168.2.1",
+		"192.168.2.2",
+	})
+
+	log.Println(ips)
+
+	log.Println(ParseIPs2Strings(ips))
+}


### PR DESCRIPTION
Then developers can use the `make start` to start the **resp-api** application.